### PR TITLE
Cria agenda ao cadastrar usuário

### DIFF
--- a/src/main/java/br/com/deveficiente/calendario/CalendarioApplication.java
+++ b/src/main/java/br/com/deveficiente/calendario/CalendarioApplication.java
@@ -2,8 +2,10 @@ package br.com.deveficiente.calendario;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
+@EnableJpaRepositories(enableDefaultTransactions = false)
 public class CalendarioApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/br/com/deveficiente/calendario/controller/UsuarioController.java
+++ b/src/main/java/br/com/deveficiente/calendario/controller/UsuarioController.java
@@ -1,7 +1,9 @@
 package br.com.deveficiente.calendario.controller;
 
 import br.com.deveficiente.calendario.controller.form.NovoUsuarioForm;
+import br.com.deveficiente.calendario.model.Agenda;
 import br.com.deveficiente.calendario.model.Usuario;
+import br.com.deveficiente.calendario.repository.AgendaRepository;
 import br.com.deveficiente.calendario.repository.UsuarioRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +17,9 @@ import javax.validation.Valid;
 public class UsuarioController {
 
     @Autowired
+    private AgendaRepository agendaRepository;
+
+    @Autowired
     private UsuarioRepository usuarioRepository;
 
     @PostMapping("/api/usuario")
@@ -23,6 +28,7 @@ public class UsuarioController {
         final Usuario usuario = form.toModel();
         usuarioRepository.save(usuario);
 
-        // TODO Cria Agenda default do usuário
+        final Agenda agendaUsuario = new Agenda(usuario);
+        agendaRepository.save(agendaUsuario);
     }
 }

--- a/src/main/java/br/com/deveficiente/calendario/controller/UsuarioController.java
+++ b/src/main/java/br/com/deveficiente/calendario/controller/UsuarioController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 @RestController
@@ -17,8 +18,11 @@ public class UsuarioController {
     private UsuarioRepository usuarioRepository;
 
     @PostMapping("/api/usuario")
+    @Transactional
     public void cadastra(@RequestBody @Valid final NovoUsuarioForm form) {
         final Usuario usuario = form.toModel();
         usuarioRepository.save(usuario);
+
+        // TODO Cria Agenda default do usuário
     }
 }

--- a/src/main/java/br/com/deveficiente/calendario/controller/form/NovoUsuarioForm.java
+++ b/src/main/java/br/com/deveficiente/calendario/controller/form/NovoUsuarioForm.java
@@ -21,13 +21,18 @@ public class NovoUsuarioForm {
     @Length(min = 6)
     private final String senha;
 
-    public NovoUsuarioForm(@NotBlank @Email final String login, @NotBlank @Length(min = 6) final String senha) {
+    @NotBlank
+    private final String nome;
+
+    public NovoUsuarioForm(@NotBlank @Email final String login, @NotBlank @Length(min = 6) final String senha,
+                           @NotBlank final String nome) {
         this.login = login;
         this.senha = senha;
+        this.nome = nome;
     }
 
     public Usuario toModel() {
         final Password password = new Password(this.senha, IS_HASHED);
-        return new Usuario(this.login, password);
+        return new Usuario(this.login, password, this.nome);
     }
 }

--- a/src/main/java/br/com/deveficiente/calendario/model/Agenda.java
+++ b/src/main/java/br/com/deveficiente/calendario/model/Agenda.java
@@ -1,0 +1,36 @@
+package br.com.deveficiente.calendario.model;
+
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Entity
+public class Agenda {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotEmpty
+    private final String nome;
+
+    @Length(max = 255)
+    @NotEmpty
+    private final String descricao;
+
+    @ManyToOne
+    @NotNull
+    private final Usuario dono;
+
+    public Agenda(final String nome, final String descricao, final Usuario dono) {
+        this.nome = nome;
+        this.descricao = descricao;
+        this.dono = dono;
+    }
+}

--- a/src/main/java/br/com/deveficiente/calendario/model/Agenda.java
+++ b/src/main/java/br/com/deveficiente/calendario/model/Agenda.java
@@ -13,6 +13,8 @@ import javax.validation.constraints.NotNull;
 @Entity
 public class Agenda {
 
+    private static final String DESCRICAO_DEFAULT = "Agenda %s";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -28,9 +30,9 @@ public class Agenda {
     @NotNull
     private final Usuario dono;
 
-    public Agenda(final String nome, final String descricao, final Usuario dono) {
-        this.nome = nome;
-        this.descricao = descricao;
+    public Agenda(final Usuario dono) {
+        this.nome = dono.getNome();
+        this.descricao = String.format(DESCRICAO_DEFAULT, dono.getNome());
         this.dono = dono;
     }
 }

--- a/src/main/java/br/com/deveficiente/calendario/model/Usuario.java
+++ b/src/main/java/br/com/deveficiente/calendario/model/Usuario.java
@@ -30,12 +30,16 @@ public class Usuario {
     @Length(min = 6)
     private final String senha;
 
+    @NotBlank
+    private final String nome;
+
     @PastOrPresent
     @NotNull
     private final LocalDateTime dataCadastro = LocalDateTime.now();
 
-    public Usuario(final String login, final Password password) {
+    public Usuario(final String login, final Password password, final String nome) {
         this.login = login;
         this.senha = password.getHash();
+        this.nome = nome;
     }
 }

--- a/src/main/java/br/com/deveficiente/calendario/model/Usuario.java
+++ b/src/main/java/br/com/deveficiente/calendario/model/Usuario.java
@@ -42,4 +42,8 @@ public class Usuario {
         this.senha = password.getHash();
         this.nome = nome;
     }
+
+    public String getNome() {
+        return nome;
+    }
 }

--- a/src/main/java/br/com/deveficiente/calendario/repository/AgendaRepository.java
+++ b/src/main/java/br/com/deveficiente/calendario/repository/AgendaRepository.java
@@ -1,0 +1,9 @@
+package br.com.deveficiente.calendario.repository;
+
+import br.com.deveficiente.calendario.model.Agenda;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AgendaRepository extends CrudRepository<Agenda, Long> {
+}


### PR DESCRIPTION
### Necessidades

- [x] No momento do cadastro de uma nova pessoa, já crie também uma nova agenda. Toda agenda possui um nome, descrição e um(a) dono(a). Por hora vamos ignorar a aplicação do timezone. A dona da agenda é justamente a pessoa que está se cadastrando naquele momento.

- [x] O nome da agenda criada de forma automática precisa ser igual ao nome da pessoa que está se cadastrando.

- [x] A descrição da agenda criada de forma automática deve ser igual "Agenda {nomeDoUsuario}". Substitua {nomeDoUsuario} por pelo nome do usuário dono da agenda.

### Restrições

- [x] Nome do Usuário é obrigatório
- [x] Nome do Agenda não pode ser nulo ou vazio
- [x] Descrição da Agenda não pode ser nula, vazia e o limite máximo de caracteres é 255.
- [x] Dono(a) da Agenda não pode ser nulo.

### Resultado Esperado

Além da pessoa nova cadastrada, uma nova agenda precisa ter sido criada seguindo as necessidades e restrições.